### PR TITLE
Small fixes for EpisodeGrouper

### DIFF
--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -159,7 +159,7 @@ namespace Emby.Naming.Video
             var list = new List<VideoInfo>();
             if (collectionType.Equals(CollectionType.tvshows))
             {
-                var groupedList = mergeable.GroupBy(x => EpisodeGrouper(x.Files[0].Path, namingOptions, collectionType));
+                var groupedList = mergeable.GroupBy(x => EpisodeGrouper(x.Files[0].Path, namingOptions));
                 foreach (var grouping in groupedList)
                 {
                     list.Add(OrganizeAlternateVersions(grouping.ToList(), grouping.Key.AsSpan(), primary));
@@ -265,7 +265,7 @@ namespace Emby.Naming.Video
                    || CheckMultiVersionRegex().IsMatch(testFilename);
         }
 
-        private static string EpisodeGrouper(string testFilePath, NamingOptions namingOptions, CollectionType? collectionType)
+        private static string EpisodeGrouper(string testFilePath, NamingOptions namingOptions)
         {
             // Grouper for tv shows/episodes should be everything before space-dash-space
             var resolver = new EpisodeResolver(namingOptions);

--- a/Emby.Naming/Video/VideoListResolver.cs
+++ b/Emby.Naming/Video/VideoListResolver.cs
@@ -270,9 +270,15 @@ namespace Emby.Naming.Video
             // Grouper for tv shows/episodes should be everything before space-dash-space
             var resolver = new EpisodeResolver(namingOptions);
             var episodeInfo = resolver.Resolve(testFilePath, false);
-            ReadOnlySpan<char> seriesName = episodeInfo!.SeriesName;
 
             var filename = Path.GetFileNameWithoutExtension(testFilePath);
+            if (episodeInfo == null)
+            {
+                return filename;
+            }
+
+            ReadOnlySpan<char> seriesName = episodeInfo.SeriesName;
+
             // Start with grouping by filename
             string g = filename;
             for (var i = 0; i < namingOptions.VideoVersionRegexes.Length; i++)


### PR DESCRIPTION
Hello,

today I got an exception, because of an invalid episode file name. In this case `EpisodeResolver.Resolve()` returns `null` and accessing the series name produces a NullReferenceException.

If you agree with my changes, please update your PR https://github.com/jellyfin/jellyfin/pull/8004

Thank you :)